### PR TITLE
Failing test in combineReducers exercise

### DIFF
--- a/intro/exercises-final/00-reducers/03-combined-reducer.html
+++ b/intro/exercises-final/00-reducers/03-combined-reducer.html
@@ -87,7 +87,7 @@
 
             const result = rootReducer(undefined, action);
 
-            assert(result.users.length === state.users.length + 1, "Should have added one item");
+            assert(result.users.length === rootReducerInitialState.users.length + 1, "Should have added one item");
             assert(result !== rootReducerInitialState, "Must create a new state object");
         },
     })

--- a/intro/exercises/00-reducers/03-combined-reducer.html
+++ b/intro/exercises/00-reducers/03-combined-reducer.html
@@ -83,7 +83,7 @@
 
             const result = rootReducer(undefined, action);
 
-            assert(result.users.length === state.users.length + 1, "Should have added one item");
+            assert(result.users.length === rootReducerInitialState.users.length + 1, "Should have added one item");
             assert(result !== rootReducerInitialState, "Must create a new state object");
         },
     })


### PR DESCRIPTION
The final test in 00-reducers/03-combined-reducer incorrectly makes an assertion against a state variable (which is undefined). I believe the assertion should be made against the rootReducerInitialState variable. This pull request makes this change in both /exercises and /exercises-final. 